### PR TITLE
Added nypd-crime-complaint-data-historic-2006-2019 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,19 @@
-# Open Source Machine Learning Datasets
-This repository holds open-source datasets for various machine learning domains ready to download and use for ML!
----
+# Here are the details about the database:
 
-**Welcome to DagsHub’s non-code contribution project for Hacktoberfest 2023!**
+## **Description**:
+These data represent criminal offenses according to New York State Penal Law definitions, not FBI Uniform Crime Report definitions, and are therefore not comparable to UCR reported crime.This dataset includes all valid felony, misdemeanor, and violation crimes reported to the New York City Police Department (NYPD) from 2006 to the end of year 2019.Each record represents a criminal complaint in NYC and includes information about the type of crime, the location and time of enforcement.
+In addition, information related to victim and suspect demographics is also included.This data can be used by the public to explore the nature of criminal activity.
 
-![hero-narrow](https://github.com/DagsHub/open-source-ml-datasets/assets/66431403/ce84ea17-7ca4-4e44-8ca1-7785074b847f)
+## **Citation**:
+This data is manually extracted every quarter and reviewed by the Office of Management Analysis and Planning.
 
+## **Prerequisite**:
+1. Basic knowledge of processing textual data.
+2. Visualization techniques in Python.(Matplotlib,Seaborn etc)
 
-In this exciting Hacktoberfest challenge, DagsHub invites you to join us in enriching the open-source dataset domain and enhancing its accessibility and capabilities for the global machine-learning community.
+## **License**:
+Taken From Kaggle.
+CC0: Public Domain
 
-## What is DagsHub?
-[DagsHub](https://dagshub.com/) is a centralized platform to host and manage machine learning projects including code, data, models, experiments, annotations, model registry, and more! DagsHub does the MLOps heavy lifting for its users. Every repository comes with configured S3 storage, an experiment tracking server, and an annotation workspace - all using popular open-source tools like MLflow, DVC, Git, and Label Studio.
-
-## What is this challenge?
-**Your mission is to import datasets from various sources**, such as Kaggle, Hugging Face, or any other relevant platforms, and integrate them into DagsHub. Hosting those datasets on DagsHub exposes them to our Data Engine, unlocking unique data management capabilities such as query, visualize, annotate, and streaming for ML training. Not only that, by adding crucial information and context to these datasets, you'll significantly boost their accessibility and usability. 
-
-## How do I contribute?
-To simplify this process, we've created a user-friendly Colab notebook that will do the import for you! Here's a quick overview of what you need to do:
-1. Sign-up to [Hacktoberfest](https://hacktoberfest.digitalocean.com/profile) & [DagsHub](https://dagshub.com/user/sign_up?redirect_to=).
-2. Join [Hacktoberfest 2023 Discord channel](https://discord.gg/xAGgkNht).
-3. Claim the dataset by opening a new issue [here](https://github.com/DagsHub/open-source-ml-datasets) and naming it after the dataset. Please make sure that the dataset wasn't claimed and that it’s open source.
-4. Import a Dataset using those Colab notebooks: [Hugging Face notebook](https://colab.research.google.com/drive/1WD5V2Xp4nRm1t1LrawqZgW4IqRryQZ9N?usp=sharing) or [Kaggle notebook](https://colab.research.google.com/drive/16PV-m1IgeqG0PBNnySWkvHGLHpghalJT?usp=sharing).
-5. Add a [README.md](http://README.md) file (e.g., [Librispeech ASR corpus](https://dagshub.com/DagsHub/Librispeech-ASR-corpus/src/master/README.md)) **to the repository on DagsHub** with the following information:
-    1. Description
-    2. Citation
-    3. Prerequisite
-    4. License 
-    5. Additional information
-    
-    **Note:** You can create a [markdown file](https://www.markdownguide.org/getting-started/) locally, upload it to DagsHub from the repository UI, and edit it from DagsHub - no need for coding whatsoever!
-6. Add relevant tags to the repository and files.
-7. Add the `dataset`, `hacktoberfest-2023`, `hacktoberfest` labels to the DagsHub repository.
-8. Open a Pull Request on [here](https://github.com/DagsHub/open-source-ml-datasets) with the README file and a link to the DagsHub repo.
+## **Additional Information**:
+More information : https://www.kaggle.com/datasets/brunacmendes/nypd-complaint-data-historic-20062019


### PR DESCRIPTION
DagsHub Repo - [https://dagshub.com/plon-Susk7/nypd-crime-complaint-data-historic-2006-2019](url)

Created the README.md with the necessary details.

This PR closes the issue #8 
